### PR TITLE
Move `semantic-release` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
       "main"
     ]
   },
-  "dependencies": {
+  "devDependencies": {
     "semantic-release": "^25.0.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
Semantic-release creates a bunch of vulnerabilities, but it isn't a dependency at all, as it is used only for releasing a new version